### PR TITLE
Updated parseFeature to work with cucumber-expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You'll need to add the following to your jest config:
   ],
   "transform": {
     "^.+\\.(js|jsx|ts|tsx)$": "babel-jest",
-    "^.+\\.(feature)$": "jest-cucumber" // <--- *3
+    "^.+\\.(feature)$": "cucumber-jest" // <--- *3
   },
   "testMatch": [
     "<rootDir>/path/to/your/*.feature" // <--- *4
@@ -90,7 +90,7 @@ You'll need to add the following to your jest config:
       hooks / steps
     - it's important to note that this file must be list first in the *setupFilesAfterEnv* list of files; before your
       world, hooks, or step files
-3. Add ```"^.+\\.(feature)$": "jest-cucumber"``` as a *transformer*
+3. Add ```"^.+\\.(feature)$": "cucumber-jest"``` as a *transformer*
 4. Add ```"<rootDir>/path/to/your/*.feature"``` as a *testMatch* pattern
 
 ## Example

--- a/example/test/steps.ts
+++ b/example/test/steps.ts
@@ -7,7 +7,7 @@ Given(/^the (\S+) component rendered$/, async function (this: TestWorld, name) {
     await this[name].click();
 });
 
-When(/^the (\S+) button is clicked$/, async function (this: TestWorld, name) {
+When('the {word} button is clicked', async function (this: TestWorld, name) {
 
     await this[name].click();
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "./build.sh"
+    "build": "./build.sh",
+    "copy:build": "cp -rf ./dist ./example/node_modules/cucumber-jest/"
   },
   "repository": {
     "type": "git",

--- a/src/utils/parseFeature.ts
+++ b/src/utils/parseFeature.ts
@@ -207,9 +207,7 @@ function bindGherkinSteps(steps, definitions) {
             )).join('\n')}\n`);
         }
 
-        const args = definition.pattern ?
-            Array.from(definition.pattern.exec(step.text)).slice(1) :
-            [];
+        const args = Array.from(definition.expression?.regexp?.exec(step.text) || []).slice(1)
 
         const stepArgs = [
             ...args,


### PR DESCRIPTION
Hello,

In integrating `cucumber-jest` with one of my team's repos, I noticed it did not work with [cucumber-expressions](https://cucumber.io/docs/cucumber/cucumber-expressions/). So I went ahead and made this simple update to correct that:
* I updated the `parseFeature` function to use the `StepDefinition.expression.regexp` getter to obtain the regex. This replaces the use of `definition.pattern`, which sometimes resolved to a string, not regex, which would throw an error when attempting to call `.exec` method. 
  * Using `definition.expression.regexp` ensures the regexp object is obtained, regardless of whether the step definition uses regex or cucumber expressions
  * I tested this using your example app. I updated one of the step definitions to use a cucumber expression, and all the tests pass.
* I also noticed the `README.md` instructs readers to use the package `jest-cucumber` for the jest transformer, but that is a [different package](https://github.com/bencompton/jest-cucumber#readme) and does not export a transformer `process`. I simply changed it to `cucumber-jest`.

I hope this is helpful.
