### PR TITLE
[WIP] Generate snippet for undefined steps

### DIFF
--- a/src/parsers/steps.ts
+++ b/src/parsers/steps.ts
@@ -7,6 +7,20 @@ import {space} from '../configs/space';
 import {isJson} from '../utils/isJson';
 import {createDataTable} from './table';
 
+export function generateSnippet(step): string {
+    return outdent`
+        ${chalk.red(
+            '[error]'
+        )} could not find a step with pattern that matches the text:\n		
+        ${chalk.yellow(step.text)}\n
+        Implement with the following snippet:\n
+        ${step.keyword.trim()}("${step.text}", function () {
+            // Write code here
+        });
+        \n
+    `;
+}
+
 export function parseSteps(steps, definitions) {
     return reduce(
         steps,
@@ -20,12 +34,7 @@ export function parseSteps(steps, definitions) {
             });
 
             if (!definition) {
-                throw new Error(outdent`
-                    ${chalk.red(
-                        '[error]'
-                    )} could not find a step with pattern that matches the text:\n
-                    ${chalk.yellow(step.text)}\n
-                `);
+                throw new Error(generateSnippet(step));
             }
 
             if (multiSteps.length > 1) {


### PR DESCRIPTION
Similar to what cucuber-js does with useForSnippets.

Ex: 
```bash
    [error] could not find a step with pattern that matches the text:

    an undefined step text

    Implement with the following snippet:

    And("an undefined step text", function () {
        // Write code here
    });
```

ToDo:
- [ ] Add tests? (need to setup the environment for testing failed tests)
- [ ] Generate snippet for steps with variables/examples?

Closes #11